### PR TITLE
fix two small issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To download and unpack:
 ```
 VERSION=0.0.1
 curl -OL https://github.com/delta-incubator/dat/releases/download/v$VERSION/deltalake-dat-v$VERSION.tar.gz
-tar -xzvf deltalake-dat-v$VERSION.tar.gz
+tar  --no-same-permissions -xzf deltalake-dat-v$VERSION.tar.gz
 ```
 
 ## Testing Readers

--- a/dat/models.py
+++ b/dat/models.py
@@ -23,7 +23,7 @@ class TestCaseInfo(BaseModel):
         return self.root / 'expected' / version_path
 
     def expected_path(self, version: Optional[int] = None) -> str:
-        return str(self.expected_root(version) / 'table_content.parquet')
+        return str(self.expected_root(version) / 'table_content')
 
 
 class TableVersionMetadata(BaseModel):

--- a/tests/pyspark_delta/test_pyspark_delta.py
+++ b/tests/pyspark_delta/test_pyspark_delta.py
@@ -42,7 +42,7 @@ for path in (TEST_ROOT / 'generated').iterdir():
                 case = ReadCase(
                     delta_root=path / 'delta',
                     version=version,
-                    parquet_root=version_path,
+                    parquet_root=version_path / "table_content",
                     name=case_metadata['name'],
                     description=case_metadata['description'],
                     min_reader_version=expected_metadata['min_reader_version'],


### PR DESCRIPTION
Two changes:

 * Adds `--no-same-permissions` flag to tar command, which avoids issues on Mac OS untaring. The reason we want to use tar over zip is that [tar is better at compressing a large number of files](), which is precisely what we have in our output.
 * Renamed `table_content.parquet` to simply `table_content`, since it's now a directory.


## Does this require an update to the documentation?