### PR TITLE
Fix iceberg-compat-v1 test to properly turn on column mapping

### DIFF
--- a/dat/generated_tables.py
+++ b/dat/generated_tables.py
@@ -570,4 +570,5 @@ def create_iceberg_compat_v1(case: TestCaseInfo, spark: SparkSession):
         .execute()
     )
     delta_table.upgradeTableProtocol(3, 7)
+    delta_table.addFeatureSupport("columnMapping")
     df.repartition(1).write.format("delta").mode("append").save(case.delta_root)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
 
  1. If the PR is unfinished, add '[DRAFT]' in your PR title, e.g., '[DRAFT] Your PR title ...'.
  2. Be sure to keep the PR description updated to reflect all changes.
  3. Please write your PR title to summarize what this PR proposes.
  4. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe why we need the change.
- Describe what this PR changes.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge. Please link the JIRA issue if there is an associated one.
-->
The [protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#reader-requirements-for-column-mapping) requires that for column mapping to be enabled at min reader version 3, the corresponding reader feature must be set.

The table was created at min reader/writer versions 2/7 and when set to 3/7 the reader features are empty. This effectively turns off column mapping. This PR adds a new `addFeatureSupport` call to add the `columnMapping` readerFeature

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->



## Does this require an update to the documentation?