### PR TITLE
chore: mark jackson, commons-io, and scalatest as provided

### DIFF
--- a/workload-generator/build.sbt
+++ b/workload-generator/build.sbt
@@ -48,12 +48,13 @@ lazy val root = (project in file("."))
       val (deltaV, sparkV) = if (scalaBinaryVersion.value == "2.13")
         ("4.1.0", "4.1.0") else ("3.2.1", "3.5.4")
       Seq(
+        // provided: DAT test runners should already have these dependencies, so the published jar
+        // should not pull in its own versions, which may clash.
         "io.delta" %% "delta-spark" % deltaV % "provided",
         "org.apache.spark" %% "spark-sql" % sparkV % "provided",
-        "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.2",
-        "commons-io" % "commons-io" % "2.11.0",
-        // WorkloadTestSuite extends ScalaTest — needed at compile time
-        "org.scalatest" %% "scalatest" % "3.2.19",
+        "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.2" % "provided",
+        "commons-io" % "commons-io" % "2.11.0" % "provided",
+        "org.scalatest" %% "scalatest" % "3.2.19" % "provided",
         // Test dependencies
         "io.delta" %% "delta-spark" % deltaV % "test",
         "org.apache.spark" %% "spark-sql" % sparkV % "test",


### PR DESCRIPTION
## Description

`jackson-module-scala`, `commons-io`, and `scalatest` were declared in the `compile` scope even though DAT test runners already have these dependencies, resulting in collisions with DAT test runner classpaths. This change marks the three dependencies as `provided`. The DAT workload generator and the bundled `tables.*` suites still build and run, but the published artifact no longer carries them.

## How was this patch tested?
`sbt "testOnly io.delta.workload.tables.*"` (full generation + row-for-row self-validation): 699/700 pass; the one failure is the pre-existing DV-017 deletion-vectors case, unrelated to this change.